### PR TITLE
set vertical-align prop to middle for .label

### DIFF
--- a/css/override-commons.css
+++ b/css/override-commons.css
@@ -30,7 +30,8 @@ ul.loginbar li:nth-child(1) a.username:hover {
 .label {
     display: inline-block;
     border-radius: 4px !important;
-    line-height: 1.2;
+	line-height: 1.2;
+	vertical-align: middle;
     padding: 2px 2px;
 }
 


### PR DESCRIPTION
| `inherit` | `middle` |
| :--: | :--: |
|  <img width="596" alt="Screen Shot 2019-07-30 at 9 49 24 PM" src="https://user-images.githubusercontent.com/5278201/62130556-40d61300-b314-11e9-873f-80cdde9b6b9e.png"> | <img width="593" alt="Screen Shot 2019-07-30 at 9 49 05 PM" src="https://user-images.githubusercontent.com/5278201/62130673-7c70dd00-b314-11e9-81c4-3b93cfadc3b9.png"> |

기존의 `vertical-align` 의 스타일 값은 `baseline`으로, [부트스트랩에서 상속 받은](https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css) 값입니다. 

해당 값이 덮어 쓴 레이블 요소와 자연스럽지 않아 `vertical-align: middle` 값을 새로 추가했습니다.

`padding: 2px 2px` 은 의도하신 값이 맞나요? 제대로 덮어 씌웠을때 `4px 7px` 값보다 부자연스러워 보입니다.